### PR TITLE
Feat/ot151 19 mod migrat control announcement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby '2.7.2'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 
 gem 'bootsnap', '>= 1.4.4', require: false # https://rubygems.org/gems/bootsnap
+gem 'discard' # https://rubygems.org/gems/discard
 gem 'dotenv-rails', '~> 2.7', '>= 2.7.6' # https://rubygems.org/gems/dotenv-rails
 gem 'jsonapi-serializer', '~> 2.2' # https://rubygems.org/gems/jsonapi-serializer
 gem 'pg', '~> 1.1' # https://rubygems.org/gems/pg
@@ -43,5 +44,4 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'discard' # https://rubygems.org/gems/discard
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -43,4 +43,5 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'discard' # https://rubygems.org/gems/discard
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.5.0)
+    discard (1.2.1)
+      activerecord (>= 4.2, < 8)
     docile (1.1.5)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -248,6 +250,7 @@ DEPENDENCIES
   annotate (~> 3.0, >= 3.0.3)
   bootsnap (>= 1.4.4)
   brakeman (~> 5.1, >= 5.1.2)
+  discard
   dotenv-rails (~> 2.7, >= 2.7.6)
   factory_bot_rails (~> 5.1, >= 5.1.1)
   faker (~> 2.13)

--- a/app/controllers/api/v1/announcement_controller.rb
+++ b/app/controllers/api/v1/announcement_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::AnnouncementController < ApplicationController
+end

--- a/app/controllers/api/v1/announcement_controller.rb
+++ b/app/controllers/api/v1/announcement_controller.rb
@@ -1,2 +1,8 @@
-class Api::V1::AnnouncementController < ApplicationController
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class AnnouncementController < ApplicationController
+    end
+  end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: announcements

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id           :bigint           not null, primary key
+#  content      :text             not null
+#  discarded_at :datetime
+#  image_url    :string           not null
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_announcements_on_discarded_at  (discarded_at)
+#
+class Announcement < ApplicationRecord
+  include Discard::Model
+  validates :name, presence: true, length: { minimum: 3 }
+  validates :content, presence: true, length: { minimum: 3 }
+  validates :image_url, presence: true,
+                        length: { minimum: 3 }
+  # :image_url does not allow blank spaces, in any position of the string
+  validates :image_url, format: { without: /\s/, message: 'must contain no spaces' }
+end

--- a/db/migrate/-20220218231120_add_category_ref_to_announcements.rb
+++ b/db/migrate/-20220218231120_add_category_ref_to_announcements.rb
@@ -1,0 +1,5 @@
+# class AddCategoryRefToAnnouncements < ActiveRecord::Migration[6.1]
+#   def change
+#     add_reference :announcements, :category, null: false, foreign_key: true
+#   end
+# end

--- a/db/migrate/20220218230313_create_announcements.rb
+++ b/db/migrate/20220218230313_create_announcements.rb
@@ -1,0 +1,11 @@
+class CreateAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    create_table :announcements do |t|
+      t.string :name, null: false
+      t.text :content, null: false
+      t.string :image_url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220218230412_add_discarded_at_to_announcements.rb
+++ b/db/migrate/20220218230412_add_discarded_at_to_announcements.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :discarded_at, :datetime
+    add_index :announcements, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_011556) do
+ActiveRecord::Schema.define(version: 2022_02_18_230412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "people", force: :cascade do |t|
-    t.string "name"
-    t.string "address"
+  create_table "announcements", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "content", null: false
+    t.string "image_url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_announcements_on_discarded_at"
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "address"
+    t.integer "phone"
+    t.string "email", null: false
+    t.text "welcome_text", null: false
+    t.string "about_us_text"
+    t.string "image_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_organizations_on_discarded_at"
+    t.index ["email"], name: "index_organizations_on_email", unique: true
   end
 
 end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: announcements

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -17,15 +17,12 @@
 #  index_announcements_on_discarded_at  (discarded_at)
 #
 FactoryBot.define do
-  factory :announcement do
+  factory :target, class: 'Announcement' do
     name { Faker::TvShows::BreakingBad.episode }
     content { Faker::Quote.famous_last_words }
     image_url { Faker::Internet.url }
   end
-  factory :discarded, class: 'Announcement' do
-    name { Faker::TvShows::BreakingBad.episode }
-    content { Faker::Quote.famous_last_words }
-    image_url { Faker::Internet.url }
+  trait :discarded do
     discarded_at { rand(1..1_000_000).days.ago }
   end
 end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id           :bigint           not null, primary key
+#  content      :text             not null
+#  discarded_at :datetime
+#  image_url    :string           not null
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_announcements_on_discarded_at  (discarded_at)
+#
+FactoryBot.define do
+  factory :announcement do
+    name { Faker::TvShows::BreakingBad.episode }
+    content { Faker::Quote.famous_last_words }
+    image_url { Faker::Internet.url }
+  end
+  factory :discarded, class: 'Announcement' do
+    name { Faker::TvShows::BreakingBad.episode }
+    content { Faker::Quote.famous_last_words }
+    image_url { Faker::Internet.url }
+    discarded_at { rand(1..1_000_000).days.ago }
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,71 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id           :bigint           not null, primary key
+#  content      :text             not null
+#  discarded_at :datetime
+#  image_url    :string           not null
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_announcements_on_discarded_at  (discarded_at)
+#
+require 'rails_helper'
+
+RSpec.describe Announcement, type: :model do
+  # soft delete tests
+  context 'an undiscarded Announcement' do
+    let(:announcement) { create(:announcement) }
+
+    it 'is included in the default scope' do
+      expect(Announcement.all).to eq([announcement])
+    end
+
+    it 'is included in kept scope' do
+      expect(Announcement.kept).to eq([announcement])
+    end
+
+    it 'is included in undiscarded scope' do
+      expect(Announcement.undiscarded).to eq([announcement])
+    end
+
+    it 'is not included in discarded scope' do
+      expect(Announcement.discarded).to eq([])
+    end
+  end
+
+  context 'discarded Post' do
+    let(:discarded) { create(:discarded) }
+
+    it 'is included in the default scope' do
+      expect(Announcement.all).to eq([discarded])
+    end
+
+    it 'is not included in kept scope' do
+      expect(Announcement.kept).to eq([])
+    end
+
+    it 'is not included in undiscarded scope' do
+      expect(Announcement.undiscarded).to eq([])
+    end
+
+    it 'is included in discarded scope' do
+      expect(Announcement.discarded).to eq([discarded])
+    end
+  end
+
+  # validation test
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_length_of(:name).is_at_least(3) }
+  it { is_expected.to validate_presence_of(:content) }
+  it { is_expected.to validate_length_of(:content).is_at_least(3) }
+  it { is_expected.to validate_presence_of(:image_url) }
+  it { is_expected.to validate_length_of(:image_url).is_at_least(3) }
+  it { is_expected.not_to allow_value('string with empty spaces').for(:image_url) }
+  it { is_expected.not_to allow_value(' ').for(:image_url) }
+  it { is_expected.not_to allow_value(' string with empty spaces ').for(:image_url) }
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: announcements
@@ -18,43 +20,43 @@ require 'rails_helper'
 
 RSpec.describe Announcement, type: :model do
   # soft delete tests
-  context 'an undiscarded Announcement' do
+  context 'with an undiscarded Announcement' do
     let(:announcement) { create(:announcement) }
 
     it 'is included in the default scope' do
-      expect(Announcement.all).to eq([announcement])
+      expect(described_class.all).to eq([announcement])
     end
 
     it 'is included in kept scope' do
-      expect(Announcement.kept).to eq([announcement])
+      expect(described_class.kept).to eq([announcement])
     end
 
     it 'is included in undiscarded scope' do
-      expect(Announcement.undiscarded).to eq([announcement])
+      expect(described_class.undiscarded).to eq([announcement])
     end
 
     it 'is not included in discarded scope' do
-      expect(Announcement.discarded).to eq([])
+      expect(described_class.discarded).to eq([])
     end
   end
 
-  context 'discarded Post' do
+  context 'with discarded Announcement' do
     let(:discarded) { create(:discarded) }
 
     it 'is included in the default scope' do
-      expect(Announcement.all).to eq([discarded])
+      expect(described_class.all).to eq([discarded])
     end
 
     it 'is not included in kept scope' do
-      expect(Announcement.kept).to eq([])
+      expect(described_class.kept).to eq([])
     end
 
     it 'is not included in undiscarded scope' do
-      expect(Announcement.undiscarded).to eq([])
+      expect(described_class.undiscarded).to eq([])
     end
 
     it 'is included in discarded scope' do
-      expect(Announcement.discarded).to eq([discarded])
+      expect(described_class.discarded).to eq([discarded])
     end
   end
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -19,55 +19,57 @@
 require 'rails_helper'
 
 RSpec.describe Announcement, type: :model do
-  # soft delete tests
-  context 'with an undiscarded Announcement' do
-    let(:announcement) { create(:announcement) }
+  describe 'soft delete' do
+    context 'with an undiscarded Announcement' do
+      subject(:target) { create(:target) }
 
-    it 'is included in the default scope' do
-      expect(described_class.all).to eq([announcement])
+      it 'is included in the default scope' do
+        expect(described_class.all).to eq([target])
+      end
+
+      it 'is included in kept scope' do
+        expect(described_class.kept).to eq([target])
+      end
+
+      it 'is included in undiscarded scope' do
+        expect(described_class.undiscarded).to eq([target])
+      end
+
+      it 'is not included in discarded scope' do
+        expect(described_class.discarded).to eq([])
+      end
     end
 
-    it 'is included in kept scope' do
-      expect(described_class.kept).to eq([announcement])
-    end
+    context 'with discarded Announcement' do
+      subject(:target) { create(:target, :discarded) }
 
-    it 'is included in undiscarded scope' do
-      expect(described_class.undiscarded).to eq([announcement])
-    end
+      it 'is included in the default scope' do
+        expect(described_class.all).to eq([target])
+      end
 
-    it 'is not included in discarded scope' do
-      expect(described_class.discarded).to eq([])
+      it 'is not included in kept scope' do
+        expect(described_class.kept).to eq([])
+      end
+
+      it 'is not included in undiscarded scope' do
+        expect(described_class.undiscarded).to eq([])
+      end
+
+      it 'is included in discarded scope' do
+        expect(described_class.discarded).to eq([target])
+      end
     end
   end
 
-  context 'with discarded Announcement' do
-    let(:discarded) { create(:discarded) }
-
-    it 'is included in the default scope' do
-      expect(described_class.all).to eq([discarded])
-    end
-
-    it 'is not included in kept scope' do
-      expect(described_class.kept).to eq([])
-    end
-
-    it 'is not included in undiscarded scope' do
-      expect(described_class.undiscarded).to eq([])
-    end
-
-    it 'is included in discarded scope' do
-      expect(described_class.discarded).to eq([discarded])
-    end
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_least(3) }
+    it { is_expected.to validate_presence_of(:content) }
+    it { is_expected.to validate_length_of(:content).is_at_least(3) }
+    it { is_expected.to validate_presence_of(:image_url) }
+    it { is_expected.to validate_length_of(:image_url).is_at_least(3) }
+    it { is_expected.not_to allow_value('string with empty spaces').for(:image_url) }
+    it { is_expected.not_to allow_value(' ').for(:image_url) }
+    it { is_expected.not_to allow_value(' string with empty spaces ').for(:image_url) }
   end
-
-  # validation test
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_length_of(:name).is_at_least(3) }
-  it { is_expected.to validate_presence_of(:content) }
-  it { is_expected.to validate_length_of(:content).is_at_least(3) }
-  it { is_expected.to validate_presence_of(:image_url) }
-  it { is_expected.to validate_length_of(:image_url).is_at_least(3) }
-  it { is_expected.not_to allow_value('string with empty spaces').for(:image_url) }
-  it { is_expected.not_to allow_value(' ').for(:image_url) }
-  it { is_expected.not_to allow_value(' string with empty spaces ').for(:image_url) }
 end

--- a/spec/requests/api/v1/announcement_spec.rb
+++ b/spec/requests/api/v1/announcement_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Announcements", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/announcement_spec.rb
+++ b/spec/requests/api/v1/announcement_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe "/api/v1/Announcements", type: :request do
-# end
+RSpec.describe '/api/v1/Announcements', type: :request do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/v1/announcement_spec.rb
+++ b/spec/requests/api/v1/announcement_spec.rb
@@ -1,7 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe "Api::V1::Announcements", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end
+# require 'rails_helper'
+
+# RSpec.describe "/api/v1/Announcements", type: :request do
+# end


### PR DESCRIPTION
### Soft Delete
Se añaden la gema [discard](https://github.com/jhawthorn/discard) para implementar _soft delete_. La migración _20220218230412_add_discarded_at_to_announcements.rb_ añade la columna necesaria para implementar _soft delete_.

---
### Versionado de Api
Se utiliza la estructura de directorio _app/controllers/api/v1/_ para almacenar el controlador _announcement_controller.rb_.

---
### migración de Foreign Key
El archivo _db/migrate/-20220218231120_add_category_ref_to_announcements.rb_ corresponde a la migración para añadir una _foreign key_ una vez que existe y se ejecute previamente la migracion de tabla `categories`.
Antes de ejecutar la migración se debe:
- Renombrar _-20220218231120_add_category_ref_to_announcements_ quitando el el signo de guion medio (`-`) y de ser nesesario, cambiando el valor de la marca de tiempo.
- Quitar todos los comentarios del codigo.

---
### Casos de prueba
Se escriben casos de prueba para las validaciones y para probar la implementación de _soft delete_ de la gema __discard__.