### PR TITLE
feat/OT151-27: add migration and model for slide

### DIFF
--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: slides
+#
+#  id              :bigint           not null, primary key
+#  discarded_at    :datetime
+#  order           :integer          not null
+#  text            :text
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_slides_on_discarded_at               (discarded_at)
+#  index_slides_on_organization_id            (organization_id)
+#  index_slides_on_organization_id_and_order  (organization_id,order) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+class Slide < ApplicationRecord
+  include Discard::Model
+
+  has_one_attached :image
+  belongs_to :organization
+  validate :check_image_presence
+  validates :order, presence: true,
+                    numericality: { only_integer: true,
+                                    greater_than: 0 }
+  def check_image_presence
+    errors.add(:image, 'no image file added') unless image.attached?
+  end
+end

--- a/db/migrate/20220224194045_create_slides.rb
+++ b/db/migrate/20220224194045_create_slides.rb
@@ -1,0 +1,12 @@
+class CreateSlides < ActiveRecord::Migration[6.1]
+  def change
+    create_table :slides do |t|
+      t.text :text
+      t.integer :order, null: false
+      t.references :organization, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :slides, [:organization_id, :order], unique: true
+  end
+end

--- a/db/migrate/20220224201414_add_discarded_at_to_slides.rb
+++ b/db/migrate/20220224201414_add_discarded_at_to_slides.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToSlides < ActiveRecord::Migration[6.1]
+  def change
+    add_column :slides, :discarded_at, :datetime
+    add_index :slides, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_23_015808) do
+ActiveRecord::Schema.define(version: 2022_02_24_201414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,18 @@ ActiveRecord::Schema.define(version: 2022_02_23_015808) do
     t.index ["discarded_at"], name: "index_roles_on_discarded_at"
   end
 
+  create_table "slides", force: :cascade do |t|
+    t.text "text"
+    t.integer "order", null: false
+    t.bigint "organization_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_slides_on_discarded_at"
+    t.index ["organization_id", "order"], name: "index_slides_on_organization_id_and_order", unique: true
+    t.index ["organization_id"], name: "index_slides_on_organization_id"
+  end
+
   create_table "testimonials", force: :cascade do |t|
     t.string "name", null: false
     t.string "content"
@@ -124,5 +136,6 @@ ActiveRecord::Schema.define(version: 2022_02_23_015808) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "announcements", "categories"
+  add_foreign_key "slides", "organizations"
   add_foreign_key "users", "roles"
 end

--- a/spec/factories/slides.rb
+++ b/spec/factories/slides.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: slides
+#
+#  id              :bigint           not null, primary key
+#  discarded_at    :datetime
+#  order           :integer          not null
+#  text            :text
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_slides_on_discarded_at               (discarded_at)
+#  index_slides_on_organization_id            (organization_id)
+#  index_slides_on_organization_id_and_order  (organization_id,order) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+FactoryBot.define do
+  factory :slide do
+    text { Faker::Books::Lovecraft.sentence }
+    order { Faker::Number.number(digits: 3) }
+
+    trait :discarded do
+      discarded_at { rand(1..1_000_000).days.ago }
+    end
+
+    after(:build) do |announcement|
+      announcement.image.attach(
+        io: File.open(Rails.root.join('spec/factories_files/test.png')),
+        filename: 'test.png', content_type: 'image/jpeg'
+      )
+    end
+
+    organization
+  end
+end

--- a/spec/models/slide_spec.rb
+++ b/spec/models/slide_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: slides
+#
+#  id              :bigint           not null, primary key
+#  discarded_at    :datetime
+#  order           :integer          not null
+#  text            :text
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_slides_on_discarded_at               (discarded_at)
+#  index_slides_on_organization_id            (organization_id)
+#  index_slides_on_organization_id_and_order  (organization_id,order) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+require 'rails_helper'
+
+RSpec.describe Slide, type: :model do
+  subject { build(:slide) }
+
+  describe 'factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'associations' do
+    it { is_expected.to have_one_attached(:image) }
+    it { is_expected.to belong_to(:organization) }
+  end
+
+  describe 'database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:order).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:text).of_type(:text) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+    it { is_expected.to have_db_index(%i[organization_id order]).unique(true) }
+  end
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados en este branch
- **db/schema.rb**: Modificado al ejecutar las migraciones.

---
Nuevos archivos
- **app/models/slide.rb**: Correspondiente al modelo.
- **db/migrate/**
  + **20220224194045_create_slides.rb**: Crea la tabla `slides`, define la referencia a la tabla `organizations` y se propone como indice con restricción de unicidad entre los valores de las columnas `organization_id` y `order` (_slides_ de una misma _organización_, no pueden tener el mismo número _orden_).
  + **20220224201414_add_discarded_at_to_slides.rb**: Para implementar _soft delete_ provisto por la gema discard.
- **spec/factories/slides.rb**
- **spec/models/slide_spec.rb**


### Comentario/s:
El modelo establece la restricción de
> *no persistir una instancia de **Slide** sin que este tenga adjunto una imagen*  
mediante la definición de del validator `check_image_presence`.

El modelo ***Annuncement*** también implemente este método, se propone realizar una _refactor_ de este método en el futuro.