### PR TITLE
feat/OT151-31: add middleware for ownership

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  include Authorized
 end

--- a/app/controllers/concerns/authorized.rb
+++ b/app/controllers/concerns/authorized.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Authorized
+  def admin?
+    @current_user.role.name == 'admin'
+  end
+
+  def owner?
+    params[:id].to_i == @current_user.id
+  end
+
+  def ownership?
+    render json: { errors: 'Unauthorized access' }, status: :forbidden unless admin? || owner?
+  end
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados en este branch
- **Gemfile**: Añade la gema `jwt`
- **app/controllers/application_controller.rb**: incluye los modulos `Authenticable` y `Authorized` que intervienen en la autorizacion.

---
Nuevos archivos
- **app/controllers/concerns/authorized.rb**: Implementa el requerimiento del ticket
- **app/lib/json_web_token.rb**: Clase responsable de generar el tocken y decodificarlo. ***Este es un archivo de soporte, implementa requerimientos de otro/s ticket/s necesarios***.
- **app/controllers/concerns/authenticable.rb**: Verifica si el usuario inicia ha iniciado sesion y obtiene el `@current_user`. ***Este es un archivo de soporte, implementa requerimientos de otro/s ticket/s necesarios***.


### Comentario/s:
- Generar tocken
Si ya existen usuario en la db, se puede generar el tocken con los siguientes comandos
```
$ rails c
Running via Spring preloader in process 27202
Loading development environment (Rails 6.1.4.6)
[1] pry(main)> JsonWebToken.encode(user_id: 1)
=> "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJleHAiOjE2NDYxNDY2NjF9.CzpEHN5mBBhRl_x7s5AGYo99DF_0qmjFPptN3fSMvI0"
[2] pry(main)> JsonWebToken.encode(user_id: 2)
=> "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJleHAiOjE2NDYxNDY2NjZ9.m98_oT2usV8O8SdjCp6oYOGm-NntOLI5XZKpp3sbzrI"
```
> NOTA: Se asume que solo uno de los dos usuarios de `id` igual a `1` o `2` es administrador.

- Proteger el los endpoints
Actualizar el controlador de `users`
```
# app/controllers/api/v1/users_controller.rb
module Api
  module V1
    class UsersController < ApplicationController
      before_action :authorize_request, except: :create
      before_action :ownership?, except: :create
      # [...]
    end
  end
end
```
