### PR TITLE
Feat/ot151 32 user update endpoint

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -43,7 +43,11 @@ module Api
 
       def user_params
         params.require(:user).permit(:email, :password, :first_name, :last_name)
-      end    
+<<<<<<< HEAD
+      end
+=======
+        end
+>>>>>>> fixed typo
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,6 +13,8 @@ module Api
         render json: @users, status: :ok
       end
 
+      before_action :set_user, only: [:update]
+      before_action :ownership?, only: %i[update]
       def create
         @user = User.new(user_params)
         @user.role = Role.create_or_find_by(name: 'user', description: 'usuario de la aplicacion')
@@ -25,16 +27,16 @@ module Api
       end
 
       def update
-        @user = current_user
         if @user.update(user_params)
-          render json: @user, status: :ok
+          render json: UserSerializer.new(@user).serializable_hash.to_json
         else
-          render json: { errors: user.errors }, status: :unprocessable_entity
+          render json: @user.errors, status: :unprocessable_entity
         end
       end
 
       private
 
+<<<<<<< HEAD
       def find_user
         @user = User.find(params[:id])
       rescue ActiveRecord::RecordNotFound
@@ -44,6 +46,15 @@ module Api
       def user_params
         params.permit(:email, :password, :first_name, :last_name)
       end
+=======
+      def set_user
+        @user = User.find(params[:id])
+      end
+
+      def user_params
+        params.require(:user).permit(:email, :password, :first_name, :last_name)
+      end0
+>>>>>>> Agregado un método set_user y serialización
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -43,11 +43,7 @@ module Api
 
       def user_params
         params.require(:user).permit(:email, :password, :first_name, :last_name)
-<<<<<<< HEAD
       end
-=======
-        end
->>>>>>> fixed typo
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -26,7 +26,7 @@ module Api
       end
 
       def update
-        if @user.update(user_params)
+        if @user.update!(user_params)
           render json: UserSerializer.new(@user).serializable_hash.to_json
         else
           render json: @user.errors, status: :unprocessable_entity
@@ -35,7 +35,6 @@ module Api
 
       private
 
-<<<<<<< HEAD
       def find_user
         @user = User.find(params[:id])
       rescue ActiveRecord::RecordNotFound
@@ -43,17 +42,8 @@ module Api
       end
 
       def user_params
-        params.permit(:email, :password, :first_name, :last_name)
-      end
-=======
-      def set_user
-        @user = User.find(params[:id])
-      end
-
-      def user_params
         params.require(:user).permit(:email, :password, :first_name, :last_name)
-      end0
->>>>>>> Agregado un método set_user y serialización
+      end    
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -14,7 +14,6 @@ module Api
       end
 
       before_action :set_user, only: [:update]
-      before_action :ownership?, only: %i[update]
       def create
         @user = User.new(user_params)
         @user.role = Role.create_or_find_by(name: 'user', description: 'usuario de la aplicacion')

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -23,6 +23,15 @@ module Api
         end
       end
 
+      def update
+        @user = current_user
+        if @user.update(user_params)
+          render json: @user, status: :ok
+        else
+          render json: { errors: user.errors }, status: :unprocessable_entity
+        end
+      end
+
       private
 
       def find_user

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      before_action :authenticate_with_token!, only: %i[update]
       before_action :authorize_request, except: :create
       before_action :find_user, except: %i[create]
       before_action :admin, only: %i[index]

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -12,7 +12,11 @@ module ExceptionHandler
     rescue_from ActiveRecord::RecordNotFound do |e|
       render json: { message: e.message }, status: :not_found
     end
+<<<<<<< HEAD
     rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
+=======
+    rescue_from ActiveRecord::RecordInvalid, with: :four_twenty_two
+>>>>>>> Added serializer and exception handler
     rescue_from ActionController::ParameterMissing do |e|
       render json: { error: e.message }, status: :bad_request
     end
@@ -24,7 +28,11 @@ module ExceptionHandler
     render json: { ok: false }, status: :unauthorized
   end
 
+<<<<<<< HEAD
   def handle_record_invalid(errors)
+=======
+  def four_twenty_two(errors)
+>>>>>>> Added serializer and exception handler
     render json: { message: errors.message }, status: :unprocessable_entity
   end
 end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -12,11 +12,7 @@ module ExceptionHandler
     rescue_from ActiveRecord::RecordNotFound do |e|
       render json: { message: e.message }, status: :not_found
     end
-<<<<<<< HEAD
     rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
-=======
-    rescue_from ActiveRecord::RecordInvalid, with: :four_twenty_two
->>>>>>> Added serializer and exception handler
     rescue_from ActionController::ParameterMissing do |e|
       render json: { error: e.message }, status: :bad_request
     end
@@ -28,11 +24,7 @@ module ExceptionHandler
     render json: { ok: false }, status: :unauthorized
   end
 
-<<<<<<< HEAD
   def handle_record_invalid(errors)
-=======
-  def four_twenty_two(errors)
->>>>>>> Added serializer and exception handler
     render json: { message: errors.message }, status: :unprocessable_entity
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       post 'auth/login', to: 'auth#create'
       resources :categories, only: [:create]
       post '/organization/public', to: 'organizations#create'
+      resources :users, only: [:update]
     end
   end
 end


### PR DESCRIPTION
Añadido el endpoint y su correspondiente ruta para actualizar los datos del usuario. Para autorizar la actualización, el controlador exige que lo haga el usuario autenticado actual (current_user). Podría ser recomendable (aunque no este sugerido en el ticket) que los administradores puedan actualizar remotamente el perfil de todos los demás usuarios.