### PR TITLE
Feat/ot151 37 reusable image upload service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.7.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 
+gem 'bcrypt', '~> 3.1', '>= 3.1.16' # https://rubygems.org/gems/bcrypt
 gem 'bootsnap', '>= 1.4.4', require: false # https://rubygems.org/gems/bootsnap
 gem 'discard', '~> 1.2', '>= 1.2.1' # https://rubygems.org/gems/discard
 gem 'dotenv-rails', '~> 2.7', '>= 2.7.6' # https://rubygems.org/gems/dotenv-rails

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'dotenv-rails', '~> 2.7', '>= 2.7.6' # https://rubygems.org/gems/dotenv-rail
 gem 'jsonapi-serializer', '~> 2.2' # https://rubygems.org/gems/jsonapi-serializer
 gem 'pg', '~> 1.1' # https://rubygems.org/gems/pg
 gem 'puma', '~> 5.0' # https://rubygems.org/gems/puma
-
 # gem 'rack-cors' # https://rubygems.org/gems/rack-cors
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    bcrypt (3.1.16)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     brakeman (5.2.1)
@@ -248,6 +249,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate (~> 3.0, >= 3.0.3)
+  bcrypt (~> 3.1, >= 3.1.16)
   bootsnap (>= 1.4.4)
   brakeman (~> 5.1, >= 5.1.2)
   discard (~> 1.2, >= 1.2.1)

--- a/app/controllers/api/v1/members_controller.rb
+++ b/app/controllers/api/v1/members_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MembersController < ApplicationController
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,6 +3,20 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      def create
+        @user = User.new(user_params)
+        if @user.save
+          render json: @user, status: :created
+        else
+          render json: @user.errors, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:email, :password, :first_name, :last_name)
+      end
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  include UploaderImages
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
+  include HandleImages
   self.abstract_class = true
 end

--- a/app/models/concerns/handle_images.rb
+++ b/app/models/concerns/handle_images.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module HandleImages
+  extend ActiveSupport::Concern
+  def image_path
+    image.url if image.attached?
+  rescue StandardError => e
+    e.message.to_s
+    ''
+  end
+
+  def upload_image(path_image)
+    return nil if path_image.blank?
+
+    begin
+      image.attach(
+        io: File.open(path_image),
+        filename: SecureRandom.uuid,
+        content_type: 'image/jpeg'
+      )
+    rescue Errno::ENOENT => e
+      e.message
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: members
+#
+#  id            :bigint           not null, primary key
+#  description   :text
+#  discarded_at  :datetime
+#  facebook_url  :string
+#  instagram_url :string
+#  linkedin_url  :string
+#  name          :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_members_on_discarded_at  (discarded_at)
+#
+class Member < ApplicationRecord
+  include Discard::Model
+  has_one_attached :image
+  validates :name, presence: true, length: { minimum: 2 }
+  validates :description, length: { maximum: 300 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,15 +4,15 @@
 #
 # Table name: users
 #
-#  id           :bigint           not null, primary key
-#  discarded_at :datetime
-#  email        :string           not null
-#  first_name   :string           not null
-#  last_name    :string           not null
-#  password     :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  role_id      :bigint           not null
+#  id              :bigint           not null, primary key
+#  discarded_at    :datetime
+#  email           :string           not null
+#  first_name      :string           not null
+#  last_name       :string           not null
+#  password_digest :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  role_id         :bigint           not null
 #
 # Indexes
 #
@@ -25,6 +25,8 @@
 #  fk_rails_...  (role_id => roles.id)
 #
 class User < ApplicationRecord
+  has_secure_password
+
   include Discard::Model
   belongs_to :role
   has_one_attached :image

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  namespace :api, defaults: { format: :json } do
+  namespace :api, defaults: { format: 'json' } do
     namespace :v1 do
+      post 'auth/register', to: 'users#create'
     end
   end
 end

--- a/db/migrate/20220221155708_create_members.rb
+++ b/db/migrate/20220221155708_create_members.rb
@@ -1,0 +1,14 @@
+class CreateMembers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :members do |t|
+      t.string :name, null: false
+      t.string :linkedin_url
+      t.string :facebook_url
+      t.string :instagram_url
+      t.text :description
+      t.datetime :discarded_at
+      t.index :discarded_at
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220223015406_remove_password_from_users.rb
+++ b/db/migrate/20220223015406_remove_password_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :password, :string
+  end
+end

--- a/db/migrate/20220223015808_add_password_digest_to_users.rb
+++ b/db/migrate/20220223015808_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :password_digest, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,6 +63,18 @@ ActiveRecord::Schema.define(version: 2022_02_22_172427) do
     t.index ["discarded_at"], name: "index_categories_on_discarded_at"
   end
 
+  create_table "members", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "linkedin_url"
+    t.string "facebook_url"
+    t.string "instagram_url"
+    t.text "description"
+    t.datetime "discarded_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["discarded_at"], name: "index_members_on_discarded_at"
+  end
+
   create_table "organizations", force: :cascade do |t|
     t.string "name", null: false
     t.string "address"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_22_172427) do
+ActiveRecord::Schema.define(version: 2022_02_23_015808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,11 +111,11 @@ ActiveRecord::Schema.define(version: 2022_02_22_172427) do
     t.string "email", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.string "password", null: false
     t.datetime "discarded_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "role_id", null: false
+    t.string "password_digest", null: false
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: members
+#
+#  id            :bigint           not null, primary key
+#  description   :text
+#  discarded_at  :datetime
+#  facebook_url  :string
+#  instagram_url :string
+#  linkedin_url  :string
+#  name          :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_members_on_discarded_at  (discarded_at)
+#
+FactoryBot.define do
+  factory :member do
+    name { Faker::Name.name }
+    description { Faker::Lorem.paragraph }
+    facebook_url { Faker::Internet.url(host: 'facebook.com') }
+    instagram_url { Faker::Internet.url(host: 'instagram.com') }
+    linkedin_url { Faker::Internet.url(host: 'linkedin.com', path: '/in') }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,15 +4,15 @@
 #
 # Table name: users
 #
-#  id           :bigint           not null, primary key
-#  discarded_at :datetime
-#  email        :string           not null
-#  first_name   :string           not null
-#  last_name    :string           not null
-#  password     :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  role_id      :bigint           not null
+#  id              :bigint           not null, primary key
+#  discarded_at    :datetime
+#  email           :string           not null
+#  first_name      :string           not null
+#  last_name       :string           not null
+#  password_digest :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  role_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: members
+#
+#  id            :bigint           not null, primary key
+#  description   :text
+#  discarded_at  :datetime
+#  facebook_url  :string
+#  instagram_url :string
+#  linkedin_url  :string
+#  name          :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_members_on_discarded_at  (discarded_at)
+#
+require 'rails_helper'
+
+RSpec.describe Member, type: :model do
+  subject { build(:member) }
+
+  describe 'factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'associations' do
+    it { is_expected.to have_one_attached(:image) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_least(2) }
+    it { is_expected.to validate_length_of(:description).is_at_most(300) }
+  end
+
+  describe 'database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:linkedin_url).of_type(:string) }
+    it { is_expected.to have_db_column(:facebook_url).of_type(:string) }
+    it { is_expected.to have_db_column(:instagram_url).of_type(:string) }
+    it { is_expected.to have_db_column(:description).of_type(:text) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,15 +4,15 @@
 #
 # Table name: users
 #
-#  id           :bigint           not null, primary key
-#  discarded_at :datetime
-#  email        :string           not null
-#  first_name   :string           not null
-#  last_name    :string           not null
-#  password     :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  role_id      :bigint           not null
+#  id              :bigint           not null, primary key
+#  discarded_at    :datetime
+#  email           :string           not null
+#  first_name      :string           not null
+#  last_name       :string           not null
+#  password_digest :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  role_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/requests/api/v1/users/auth_spec.rb
+++ b/spec/requests/api/v1/users/auth_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/users', type: :request do
+  let(:valid_attributes) { attributes_for(:user) }
+
+  let(:invalid_attributes) { attributes_for(:user).merge(first_name: nil) }
+
+  let(:valid_headers) { {} }
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'returns http created' do
+        post api_v1_auth_register_url,
+             params: { user: valid_attributes },
+             headers: valid_headers, as: :json
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'creates a new User' do
+        expect do
+          post api_v1_auth_register_url,
+               params: { user: valid_attributes },
+               headers: valid_headers, as: :json
+        end.to change(User, :count).by(1)
+      end
+
+      it 'renders a JSON response with the new user' do
+        post api_v1_auth_register_url,
+             params: { user: valid_attributes },
+             headers: valid_headers, as: :json
+        expect(response.content_type).to match(a_string_including('application/json'))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'returns http unproccesable entity' do
+        post api_v1_auth_register_url,
+             params: { user: invalid_attributes },
+             headers: valid_headers, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not create a new User' do
+        expect do
+          post api_v1_auth_register_url,
+               params: { user: invalid_attributes }, as: :json
+        end.to change(User, :count).by(0)
+      end
+
+      it 'renders a JSON response with errors for the new user' do
+        post api_v1_auth_register_url,
+             params: { user: invalid_attributes },
+             headers: valid_headers, as: :json
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados en este branch
- **app/models/application_record.rb**: Incluye el modulo `include HandleImages`.

---
Nuevos archivos
- **app/controllers/concerns/uploader_images.rb**: Implementa las funciones
  + `upload_image` disponible para cualquier modelo que posea la relación `has_one_attached :image`.
  + `image_url`: Para obtener la url del servicio donde esta persistido el archivo.

### Comentario/s:
- Queda pendiente, definir la estrategia para manejar excepciones.

- El método `upload_image` debería ser invocado en la acción `create` del controlador y cuando esta instanciada la clase del modelo.  
Ej:
```
  # [...]
  @user = User.new(user_params)
  @user.upload_image(params[:user][:image])
  # [...]
```

- En caso de querer adaptar el método `upload_image` para actualizar imágenes, se debería añadir `image.purge if image.attached?` antes de la linea 16, `image.attach`.

- El método `image_url` podría ser incoado dentro del serializer correspondiente al modelo.  
Ej:
```
class UserSerializer
  include JSONAPI::Serializer
  attributes :id, :email # ...
  attribute :image do |object|
    object.image_path
  end
end
```