### PR TITLE
feat/OT151-37: reusable image upload service

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,5 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  include HandleImages
 end

--- a/app/models/concerns/handle_images.rb
+++ b/app/models/concerns/handle_images.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module HandleImages
+  extend ActiveSupport::Concern
+  def image_url
+    image.url if image.attached?
+  rescue StandardError => e
+    e.message.to_s
+    ''
+  end
+
+  def upload_image(path_image)
+    return nil if path_image.blank?
+
+    begin
+      image.attach(
+        io: File.open(path_image),
+        filename: SecureRandom.uuid,
+        content_type: 'image/jpeg'
+      )
+    rescue Errno::ENOENT => e
+      e.message
+    end
+  end
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados en este branch
- **app/models/application_record.rb**: Incluye el modulo `include HandleImages`.

---
Nuevos archivos
- **app/controllers/concerns/uploader_images.rb**: Implementa las funciones
  + `upload_image` disponible para cualquier modelo que posea la relación `has_one_attached :image`.
  + `image_url`: Para obtener la url del servicio donde esta persistido el archivo.

### Comentario/s:
- Queda pendiente, definir la estrategia para manejar excepciones.

- El método `upload_image` debería ser invocado en la acción `create` del controlador y cuando esta instanciada la clase del modelo.  
Ej:
```
  # [...]
  @user = User.new(user_params)
  @user.upload_image(params[:user][:image])
  # [...]
```

- En caso de querer adaptar el método `upload_image` para actualizar imágenes, se debería añadir `image.purge if image.attached?` antes de la linea 16, `image.attach`.

- El método `image_url` podría ser incoado dentro del serializer correspondiente al modelo.  
Ej:
```
class UserSerializer
  include JSONAPI::Serializer
  attributes :id, :email # ...
  attribute :image do |object|
    object.image_url
  end
end
```