### PR TITLE
feat/OT151-45: add activity migration and model

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: activities
+#
+#  id           :bigint           not null, primary key
+#  content      :text             not null
+#  discarded_at :datetime
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_activities_on_discarded_at  (discarded_at)
+#  index_activities_on_name          (name) UNIQUE
+#
+class Activity < ApplicationRecord
+  include Discard::Model
+  has_one_attached :image
+
+  validates :name, presence: true,
+                   length: { in: 2..40 },
+                   uniqueness: { case_sensitive: false }
+  validates :content, presence: true,
+                      length: { minimum: 2 }
+end

--- a/db/migrate/20220308160411_create_activities.rb
+++ b/db/migrate/20220308160411_create_activities.rb
@@ -1,0 +1,11 @@
+class CreateActivities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :activities do |t|
+      t.string :name, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+    add_index :activities, :name, unique: true 
+  end
+end

--- a/db/migrate/20220308160425_add_discarded_at_to_activities.rb
+++ b/db/migrate/20220308160425_add_discarded_at_to_activities.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToActivities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activities, :discarded_at, :datetime
+    add_index :activities, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_24_201414) do
+ActiveRecord::Schema.define(version: 2022_03_08_160425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,16 @@ ActiveRecord::Schema.define(version: 2022_02_24_201414) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "activities", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_activities_on_discarded_at"
+    t.index ["name"], name: "index_activities_on_name", unique: true
   end
 
   create_table "announcements", force: :cascade do |t|

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: activities
+#
+#  id           :bigint           not null, primary key
+#  content      :text             not null
+#  discarded_at :datetime
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_activities_on_discarded_at  (discarded_at)
+#  index_activities_on_name          (name) UNIQUE
+#
+FactoryBot.define do
+  factory :activity do
+    name { Faker::TvShows::BreakingBad.character }
+    content { Faker::Books::Lovecraft.sentence }
+    trait :discarded do
+      discarded_at { rand(1..1_000_000).days.ago }
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: activities
+#
+#  id           :bigint           not null, primary key
+#  content      :text             not null
+#  discarded_at :datetime
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_activities_on_discarded_at  (discarded_at)
+#  index_activities_on_name          (name) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe Activity, type: :model do
+  subject { build(:activity) }
+
+  describe 'factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'associations' do
+    it { is_expected.to have_one_attached(:image) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_least(2).is_at_most(40) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+    it { is_expected.to validate_presence_of(:content) }
+    it { is_expected.to validate_length_of(:content).is_at_least(2) }
+  end
+
+  describe 'database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:content).of_type(:text).with_options(null: false) }
+    it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+    it { is_expected.to have_db_index(:name).unique }
+  end
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados en este branch
- **db/schema.rb**: Modificado al ejecutar las migraciones.

---
Nuevos archivos
- **app/models/activity.rb**: Correspondiente al modelo.
- **db/migrate/**
  + **20220308160411_create_activities.rb**: Crea la tabla `activities` y se propone como indice con restricción de unicidad la columna `name`.
  + **20220308160425_add_discarded_at_to_activities.rb**: Para implementar soft delete provisto por la gema discard.
- **spec/factories/slides.rb**
- **spec/models/slide_spec.rb**


### Comentario/s:
Antes de ejecutar el comando `bundle exec rspec spec/models/activity_spec.rb` para los test del modelo, se necesita corregir el archivo `config/storage.yml` de la rama `main` ya que posee un error de sintaxis.

El comando `rubocop` muestra ofensas para el archivo `app/mailers/user_welcome.rb:` (ajenos a la implementación de este ticket)
