### PR TITLE
Added feature to return a token when a new user registers

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,9 +4,9 @@ module Api
   module V1
     class UsersController < ApplicationController
       before_action :authenticate_with_token!, only: %i[update]
-      before_action :authorize_request, except: :create
       before_action :find_user, except: %i[create]
       before_action :admin, only: %i[index]
+      before_action :ownership?, only: %i[update]
 
       def index
         @users = User.all
@@ -16,18 +16,15 @@ module Api
       def create
         @user = User.new(user_params)
         @user.role = Role.create_or_find_by(name: 'user', description: 'usuario de la aplicacion')
-        if @user.save
-          UserNotifierMailer.send_signup_email(@user).deliver
-          render json: @user, status: :created
-          UserWelcome.with(user: @user).send_user_welcome.deliver_later
-        else
-          render json: @user.errors, status: :unprocessable_entity
-        end
+        token = JsonWebToken.encode(user_id: @user.id)
+        @user.save!
+        UserWelcome.with(user: @user).send_user_welcome.deliver_later
+        render json: { serialize_user: serialize_user, token: token }, status: :created
       end
 
       def update
         if @user.update!(user_params)
-          render json: UserSerializer.new(@user).serializable_hash.to_json
+          render json: serialize_user
         else
           render json: @user.errors, status: :unprocessable_entity
         end
@@ -39,6 +36,10 @@ module Api
         @user = User.find(params[:id])
       rescue ActiveRecord::RecordNotFound
         render json: { errors: 'User not found' }, status: :not_found
+      end
+
+      def serialize_user
+        UserSerializer.new(@user).serializable_hash.to_json
       end
 
       def user_params

--- a/app/mailers/user_welcome.rb
+++ b/app/mailers/user_welcome.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class UserWelcome < ApplicationMailer
-def send_user_welcome
+  def send_user_welcome
     @user = params[:user]
     mail(to: @user.email, subject: '¡Bienvenido a Somos Más!')
-end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
       post 'auth/login', to: 'auth#create'
       resources :categories, only: %i[create update destroy]
       post '/organization/public', to: 'organizations#create'
-      resources :users, only: %i[:update index]
+      resources :users, only: %i[update index]
     end
   end
 end


### PR DESCRIPTION
Según el [ticket 46](https://alkemy-labs.atlassian.net/browse/OT151-46?atlOrigin=eyJpIjoiMWE5MTllMmE4YTAzNDlmYjk2YzMxMjI2YWRlNzVlMDUiLCJwIjoiaiJ9), ahora al registrarse un nuevo usuario se devuelve un token para autorizar futuras requests.

También se arregló una typo en las rutas, se eliminó la constraint "authorize_request" que no existe como método y se agregó una validación para que solo los dueños de un usuario puedan editar su información (caso contrario, el token de, por ejemplo, el usuario id=>25 puede editar la información del usuario id=>34).