### PR TITLE
feat/OT151-48: add endpoint get /slides

### DIFF
--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SlidesController < ApplicationController
+      before_action :authenticate_with_token!, only: %i[index]
+      before_action :admin, only: %i[index]
+
+      # GET /api/v1/slides
+      def index
+        @slides = Slide.kept
+        render json: serialize_slides, status: :ok
+      end
+
+      private
+
+      def serialize_slides
+        SlidesSerializer.new(@slides).serializable_hash.to_json
+      end
+    end
+  end
+end

--- a/app/serializers/slides_serializer.rb
+++ b/app/serializers/slides_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SlidesSerializer
+  include JSONAPI::Serializer
+  attributes :order
+  attribute :image do |object|
+    return object.image_url if Rails.env.production?
+
+    ActiveStorage::Blob.service.path_for(object.image.key) if Rails.env.development?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,7 @@ Rails.application.routes.draw do
       post 'auth/register', to: 'users#create'
       resources :categories, only: %i[create update destroy]
       post '/organization/public', to: 'organizations#create'
-<<<<<<< HEAD
-      resources :users, only: %i[update index]
-=======
       resources :users, only: %i[index update]
->>>>>>> 08f2285 (feat OT-151-34: add endpoint authenticated user)
     end
   end
 end


### PR DESCRIPTION
### Resumen

---
No se modifican archivos de la rama `main`.

---
Nuevos archivos
- **app/controllers/api/v1/slides_controller.rb**: Implementa la acción `index` y modulariza la serialización.
- **app/serializers/slides_serializer.rb**: Para serealizar campos requeridos del ticket, de la colección de objetos, del modelo `Slide`.

---
### Comentario/s:
- La colección de registros que recupera el controlador comprenden aquellos que no se les haya aplicado un _soft delet_.
- Falta implementar el método `admin` en el módulo Authorized.
- Se necesita corregir el archivo `config/storage.yml` de la rama `main` ya que posee un error de sintaxis.
- El comando `rubocop` muestra ofensas para el archivo `app/mailers/user_welcome.rb:` (ajenos a la implementación de este ticket)
- Aun que el ticket no lo solicita, seria útil serializar la relación con la correspondiente Organización para ordenar la colección.
- Se podría considerar agregar un método en el modulo `HandleImages` para obtener el path de la imagen si el almacenamiento es local, análogo al método `image_url` para almacenamiento en **S3**. En este PR el serializer obtiene el atributo de la dirección de la imagen de la siguiente forma
```
# app/serializers/slides_serializer.rb
attribute :image do |object|
  return object.image_url if Rails.env.production?

  ActiveStorage::Blob.service.path_for(object.image.key) if Rails.env.development?
end
```