### PR TITLE
feat OT-151-51: add endpoint create testimonial

### DIFF
--- a/app/controllers/api/v1/testimonials_controller.rb
+++ b/app/controllers/api/v1/testimonials_controller.rb
@@ -3,6 +3,23 @@
 module Api
   module V1
     class TestimonialsController < ApplicationController
+      before_action :authenticate_with_token!, only: %i[create]
+      before_action :admin, only: %i[create]
+
+      def create
+        @testimonial = Testimonial.create!(testimonial_params)
+        render json: serialize_testimonial, status: :created
+      end
+
+      private
+
+      def testimonial_params
+        params.require(:testimonial).permit(:name, :content)
+      end
+
+      def serialize_testimonial
+        TestimonialSerializer.new(@testimonial).serializable_hash.to_json
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Rails.application.routes.draw do
       post 'auth/register', to: 'users#create'
       resources :categories, only: %i[show create update destroy]
       post '/organization/public', to: 'organizations#create'
-      resources :users, only: %i[index update]
+      resources :testimonials, only: %i[create]
+      resources :users, only: %i[:update index]
     end
   end
 end


### PR DESCRIPTION
COMO usuario administrador
QUIERO dar de alta nuevos Testimonios
PARA informar Novedades acerca de la ONG.

Criterios de aceptación:
POST /testimonials - Deberá validar la existencia de los campos name y content enviados, para almacenar el registro en la tabla testimonials.

Detalles a tener en cuenta:
Endpoint implmentado utilizando el [exception_handler.rb](https://github.com/alkemyTech/OT151-SERVER/blob/main/app/controllers/concerns/exception_handler.rb)