### PR TITLE
feat OT-151-43: add endpoint create announcement

### DIFF
--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -4,11 +4,18 @@ module Api
   module V1
     class AnnouncementsController < ApplicationController
       before_action :authenticate_with_token!, only: %i[update]
-      before_action :admin?, only: %i[update]
+      before_action :admin, only: %i[create]
       before_action :set_announcement, only: %i[update]
 
       def show
         render json: serialize_announcement, status: :ok
+      end
+
+      def create
+        @announcement = Announcement.new(announcement_params)
+        @announcement.type = 'news'
+        @announcement.save!
+        render json: announcement_serializer, status: :created
       end
 
       def update

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -8,6 +8,7 @@
 #  content      :text             not null
 #  discarded_at :datetime
 #  name         :string           not null
+#  type         :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  category_id  :bigint           not null
@@ -29,6 +30,7 @@ class Announcement < ApplicationRecord
 
   validates :name, presence: true, length: { minimum: 2 }
   validates :content, presence: true, length: { minimum: 2 }
+  validates :type, presence: true, length: { minimum: 2 }
   validate :check_image_presence
 
   def check_image_presence

--- a/app/serializers/announcement_serializer.rb
+++ b/app/serializers/announcement_serializer.rb
@@ -8,6 +8,7 @@
 #  content      :text             not null
 #  discarded_at :datetime
 #  name         :string           not null
+#  type         :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  category_id  :bigint           not null
@@ -24,7 +25,7 @@
 class AnnouncementSerializer
   include JSONAPI::Serializer
 
-  attributes :content, :name
-  
+  attributes :name, :content, :type
+
   belongs_to :category
 end

--- a/db/migrate/20220310003916_add_column_to_announcements.rb
+++ b/db/migrate/20220310003916_add_column_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddColumnToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :type, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2022_03_08_160425) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
     t.bigint "category_id", null: false
+    t.string "type", null: false
     t.index ["category_id"], name: "index_announcements_on_category_id"
     t.index ["discarded_at"], name: "index_announcements_on_discarded_at"
   end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -8,6 +8,7 @@
 #  content      :text             not null
 #  discarded_at :datetime
 #  name         :string           not null
+#  type         :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  category_id  :bigint           not null
@@ -25,6 +26,7 @@ FactoryBot.define do
   factory :announcement do
     name { Faker::TvShows::BreakingBad.character }
     content { Faker::Books::Lovecraft.sentence }
+    type { Faker::Lorem.word }
 
     trait :discarded do
       discarded_at { rand(1..1_000_000).days.ago }

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -8,6 +8,7 @@
 #  content      :text             not null
 #  discarded_at :datetime
 #  name         :string           not null
+#  type         :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  category_id  :bigint           not null
@@ -39,6 +40,8 @@ RSpec.describe Announcement, type: :model do
     it { is_expected.to validate_length_of(:name).is_at_least(2) }
     it { is_expected.to validate_presence_of(:content) }
     it { is_expected.to validate_length_of(:content).is_at_least(2) }
+    it { is_expected.to validate_presence_of(:type) }
+    it { is_expected.to validate_length_of(:type).is_at_least(2) }
   end
 
   describe 'database' do
@@ -46,6 +49,7 @@ RSpec.describe Announcement, type: :model do
     it { is_expected.to have_db_column(:content).of_type(:text).with_options(null: false) }
     it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:type).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
   end


### PR DESCRIPTION
COMO usuario administrador
QUIERO agregar una novedad en el sistema
PARA poder informar las Novedades de la ONG

Criterios de aceptación:
POST /news - Deberá validar la existencia de los campos enviados, para almacenar el registro en la tabla news. Antes de almacenarla, deberá asignarle la columna type con el valor "news".

Modificaciones:
Se agregaron las modificaciones de la tabla Annoucement a los archivos de test.
- **announcements.rb**
- **announcement_spec.rb**