### PR TITLE
feat/OT151-53: add pagination to members

### DIFF
--- a/app/controllers/api/v1/members_controller.rb
+++ b/app/controllers/api/v1/members_controller.rb
@@ -3,6 +3,17 @@
 module Api
   module V1
     class MembersController < ApplicationController
+      def index
+        @members = Member.kept.page(params[:page])
+        @options = get_links_serializer_options('api_v1_members_path', @members)
+        render json: serialize_members(@members, @options), status: :ok
+      end
+
+      private
+
+      def serialize_members(*args)
+        MembersSerializer.new(*args).serializable_hash.to_json
+      end
     end
   end
 end

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -7,9 +7,10 @@ module Paginable
     {
       links: {
         first: send(links_paths, page: 1),
-        last: send(links_paths, page: collection.total_pages),
         prev: send(links_paths, page: collection.prev_page),
-        next: send(links_paths, page: collection.next_page)
+        current: send(links_paths, page: collection.current_page),
+        next: send(links_paths, page: collection.next_page),
+        last: send(links_paths, page: collection.total_pages)
       }
     }
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -20,6 +20,8 @@
 #
 class Member < ApplicationRecord
   include Discard::Model
+  paginates_per 10
+
   has_one_attached :image
   validates :name, presence: true, length: { minimum: 2 }
   validates :description, length: { maximum: 300 }

--- a/app/serializers/members_serializer.rb
+++ b/app/serializers/members_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MembersSerializer
+  include JSONAPI::Serializer
+  attributes :name, :description
+  attribute :image do |object|
+    return object.image_url if Rails.env.production?
+
+    if Rails.env.development? && !object.image.key.nil?
+      ActiveStorage::Blob.service.path_for(object.image.key)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,10 @@ Rails.application.routes.draw do
       get 'auth/me', to: 'auth#show'
       post 'auth/register', to: 'users#create'
       resources :categories, only: %i[show create update destroy]
+      resources :members, only: %i[index]
       post '/organization/public', to: 'organizations#create'
       resources :testimonials, only: %i[index create]
-      resources :users, only: %i[:update index]
+      resources :users, only: %i[index update]
     end
   end
 end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados
- **Gemfile**: Añade la gema `kaminari`
- **app/controllers/application_controller.rb**: incluye el módulo `Paginable` que intervienen en la paginación.
- **app/controllers/api/v1/members_controller.rb**: Agrega la acción `index` para retornar el listado de miembros.
- **app/models/member.rb**: Añade la definición del tamaño de pagina por defecto (10 registros).
- **config/routes.rb**: Añade el Endpoint _members_ al espacio de nombres.

---
Nuevos archivos
- **app/serializers/members_serializer.rb**: Archivo generado por el comando `rails g serializer Members name description`
- **app/controllers/concerns/paginable.rb**: Implementa la generación del hash de los links a las paginas:
    + primera
    + anterior
    + actual
    + siguiente
    + ultima

---
### Comentario/s:
- Se opta por definir un numero variables de argumentos en el metodo `MembersController::serialize_members` a fin de utilizar la misma clase serializer para otras acciones del controlador que no necesiten paginación.
- Para un futuro fix, se propone un _refactor_ de las lineas 8 y 10 de `app/serializers/members_serializer.rb` para incluirlas en un nuevo método dentro del módulo `HandleImages`.
