### PR TITLE
feat/OT151-25: add module authorized

### DIFF
--- a/app/controllers/concerns/authorized.rb
+++ b/app/controllers/concerns/authorized.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Authorized
+  def admin
+    render json: { errors: 'Unauthorized access' }, status: :forbidden unless admin?
+  end
+
   def admin?
     @current_user.role.name == 'admin'
   end


### PR DESCRIPTION
Corrección del [PR#24](https://github.com/alkemyTech/OT151-SERVER/pull/24)

Se añade el método `admin` restringir los endpoints a usuario con rol de administrador.