### PR TITLE
FIxed some routes and spec tests of Users and Auth

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
       post '/organization/public', to: 'organizations#create'
       post 'auth/login', to: 'auth#create'
       post 'auth/register', to: 'users#create'
-      resources :announcements, only: %i[show, update, create]
+      resources :announcements, only: %i[show update create]
       resources :categories, only: %i[show create update destroy]
       resources :members, only: %i[index]
       resources :slides, only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,14 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: 'json' } do
     namespace :v1 do
-      resources :announcements, only: %i[show]
-      post 'auth/login', to: 'auth#create'
       get 'auth/me', to: 'auth#show'
+      post '/organization/public', to: 'organizations#create'
+      post 'auth/login', to: 'auth#create'
       post 'auth/register', to: 'users#create'
+      resources :announcements, only: %i[show, update, create]
       resources :categories, only: %i[show create update destroy]
       resources :members, only: %i[index]
-      post '/organization/public', to: 'organizations#create'
+      resources :slides, only: %i[index]
       resources :testimonials, only: %i[index create]
       resources :users, only: %i[index update destroy]
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
     it { is_expected.not_to allow_value('').for(:email) }
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
-    it { is_expected.to validate_presence_of(:password) }
+    it { is_expected.to have_secure_password(:password) }
     it { is_expected.to validate_length_of(:first_name).is_at_least(2).is_at_most(15) }
     it { is_expected.to validate_length_of(:last_name).is_at_least(2).is_at_most(15) }
     it { is_expected.to validate_length_of(:password).is_at_least(6) }
@@ -59,7 +59,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column(:first_name).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_column(:email).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_column(:last_name).of_type(:string).with_options(null: false) }
-    it { is_expected.to have_db_column(:password).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:password_digest).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }

--- a/spec/requests/api/v1/users/auth_spec.rb
+++ b/spec/requests/api/v1/users/auth_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe '/users', type: :request do
         post api_v1_auth_register_url,
              params: { user: invalid_attributes },
              headers: valid_headers, as: :json
-        expect(response.content_type).to eq('application/json')
+        expect(response.content_type).to eq('application/json; charset=utf-8')
       end
     end
   end


### PR DESCRIPTION
Agregué rutas que estaban faltando y las ordené por orden álfabetico. 
Rutas agregadas: update y create de anuncios. Index de slides.


Arreglé tres líneas de código que rompían tests. Relevante: [modelos con secure_password deben testearse usando el método de instancia de shoulda-matchers "have_secure_password"](http://matchers.shoulda.io/docs/v4.0.0.rc1/Shoulda/Matchers/ActiveModel.html#have_secure_password-instance_method)