### PR TITLE
feat/OT151-59: test endpoint users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ build-iPhoneSimulator/
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore the JSON/YAML configuration files auto-generated for rswag.
+/swagger/v1/*

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_08_160425) do
+ActiveRecord::Schema.define(version: 2022_03_10_003916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/requests/api/v1/users/auth_spec.rb
+++ b/spec/requests/api/v1/users/auth_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe '/users', type: :request do
         post api_v1_auth_register_url,
              params: { user: invalid_attributes },
              headers: valid_headers, as: :json
-        expect(response.content_type).to eq('application/json')
+        expect(response.content_type).to eq('application/json; charset=utf-8')
       end
     end
   end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  let(:invalid_params) do
+    { user: { email: '@email.com',
+              password: 'short',
+              first_name: ' ',
+              last_name: '' } }
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      before do
+        post '/api/v1/auth/register', params: { user: attributes_for(:user) }, as: :json
+      end
+
+      it 'creates a new User' do
+        expect do
+          post '/api/v1/auth/register',
+               params: { user: attributes_for(:user) },
+               as: :json
+        end.to change(User, :count).by(1)
+      end
+
+      it 'returns http 201' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'created with default role' do
+        expect(attributes_json['role_id']).to eql(Role.find_by(name: 'user').id)
+      end
+    end
+
+    context 'with invalid parameters' do
+      before do
+        post '/api/v1/auth/register', params: invalid_params, as: :json
+      end
+
+      it 'returns http 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users/destroy_spec.rb
+++ b/spec/requests/api/v1/users/destroy_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  let(:user_id) { create(:user).id }
+  let(:header_for_admin) { admin_header }
+  let(:header_for_owner) { auth_header(user_id) }
+  let(:header_for_not_owner) { auth_header(create(:user).id) }
+
+  describe 'DELETE /destroy' do
+    context 'when user is admin' do
+      before do
+        delete "/api/v1/users/#{user_id}",
+               headers: header_for_admin,
+               as: :json
+      end
+
+      it 'returns http 402' do
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'destroys the requested user' do
+        expect(User.find(user_id).discarded?).to be(true)
+      end
+    end
+
+    context 'when the user is the owner' do
+      before do
+        delete "/api/v1/users/#{user_id}",
+               headers: header_for_owner,
+               as: :json
+      end
+
+      it 'returns http 402' do
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'destroys the requested user' do
+        expect(User.find(user_id).discarded?).to be(true)
+      end
+    end
+
+    context 'when the user is not the owner' do
+      before do
+        delete "/api/v1/users/#{user_id}",
+               headers: header_for_not_owner,
+               as: :json
+      end
+
+      it 'returns http 403' do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns error message' do
+        expect(body_json['errors']).to eq('Unauthorized access')
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users/index_spec.rb
+++ b/spec/requests/api/v1/users/index_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  let!(:users) { create_list(:user, 10) }
+  let(:header_for_user) { auth_header(users.first.id) }
+  let(:header_for_admin) { admin_header }
+
+  describe 'GET /index' do
+    context 'when user is admin' do
+      before do
+        get '/api/v1/users', headers: header_for_admin, as: :json
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns all users' do
+        # admin_header create a user with 'admin' role
+        expect(body_json.size).to eq(11)
+      end
+    end
+
+    context 'when user is not admin' do
+      before do
+        get '/api/v1/users', headers: header_for_user, as: :json
+      end
+
+      it 'returns status code 403' do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns error message' do
+        expect(body_json['errors']).to eq('Unauthorized access')
+      end
+    end
+
+    context 'when not authenticated' do
+      before do
+        get '/api/v1/users', as: :json
+      end
+
+      it 'returns status code 401' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns error message' do
+        expect(body_json['errors']).to eq('Nil JSON web token')
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users/update_spec.rb
+++ b/spec/requests/api/v1/users/update_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  let(:user_id) { create(:user).id }
+  let(:header_for_admin) { admin_header }
+  let(:header_for_owner) { auth_header(user_id) }
+  let(:header_for_not_owner) { auth_header(create(:user).id) }
+  let(:admin_id) { create(:user, role_id: create(:role, name: 'admin').id).id }
+
+  let(:valid_params) do
+    { email: 'update@email.com',
+      password: 'updatepassword',
+      first_name: 'new_first_name',
+      last_name: 'new_last_name' }
+  end
+  let(:invalid_params) do
+    { email: '@email.com',
+      password: 'short',
+      first_name: ' ',
+      last_name: '' }
+  end
+
+  describe 'PUT /update' do
+    context 'when user is admin whit valid params' do
+      before do
+        put "/api/v1/users/#{user_id}",
+            params: { user: valid_params },
+            headers: header_for_admin,
+            as: :json
+      end
+
+      it 'returns http 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the requested user' do
+        expect(attributes_json['email']).to eq('update@email.com')
+        expect(attributes_json['first_name']).to eq('new_first_name')
+        expect(attributes_json['last_name']).to eq('new_last_name')
+      end
+    end
+
+    context 'when user is admin whit invalid params' do
+      before do
+        put "/api/v1/users/#{user_id}",
+            params: { user: invalid_params },
+            headers: header_for_admin,
+            as: :json
+      end
+
+      it 'returns http 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when user is owner whit valid params' do
+      before do
+        put "/api/v1/users/#{user_id}",
+            params: { user: valid_params },
+            headers: header_for_owner,
+            as: :json
+      end
+
+      it 'returns http 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the requested user' do
+        expect(attributes_json['email']).to eq('update@email.com')
+        expect(attributes_json['first_name']).to eq('new_first_name')
+        expect(attributes_json['last_name']).to eq('new_last_name')
+      end
+    end
+
+    context 'when user is owner whit invalid params' do
+      before do
+        put "/api/v1/users/#{user_id}",
+            params: { user: invalid_params },
+            headers: header_for_owner,
+            as: :json
+      end
+
+      it 'returns http 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when user is not owner' do
+      before do
+        put "/api/v1/users/#{user_id}",
+            params: { user: valid_params },
+            headers: header_for_not_owner,
+            as: :json
+      end
+
+      it 'returns http 403' do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns error message' do
+        expect(body_json['errors']).to eq('Unauthorized access')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@
 require 'simplecov'
 SimpleCov.start 'rails'
 
+require './spec/support/request_helpers'
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -48,4 +50,5 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.include RequestHelpers
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RequestHelpers
+  def body_json
+    JSON.parse(response.body)
+  end
+
+  def attributes_json
+    if body_json['serialize_user']
+      JSON.parse(body_json['serialize_user'])['data']['attributes']
+    else
+      body_json['data']['attributes']
+    end
+  end
+
+  def auth_header(user_id)
+    { 'Authorization' => "Bearer #{JsonWebToken.encode({ user_id: user_id })}" }
+  end
+
+  def admin_header
+    admin_id = create(:user, role_id: create(:role, name: 'admin').id).id
+    auth_header(admin_id)
+  end
+
+  def image_path
+    Rails.root.join('spec/factories_files/test.png')
+  end
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados
- **db/schema.rb**: Modificado al ejecutar migraciones.
- **spec/spec_helper.rb**: Incluye el módulo `RequestHelpers` para ser utilizado por todos los test.

---
Nuevos archivos
- **spec/**
  + **requests/api/v1/users_spec.rb**: Contiene los Test para el documentar el endpoint `users`
    + **index_spec.rb**
    + **create_spec.rb**
    + **update_spec.rb**
    + **destroy_spec.rb**
  + **support/request_helpers.rb**: Agrega métodos utilizados por los tests.

---
### Comentario/s:
- La acción `index` de controlador testeado, no serializa la data.