### PR TITLE
fix/OT151: change column name of announcements table

### DIFF
--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -3,9 +3,9 @@
 module Api
   module V1
     class AnnouncementsController < ApplicationController
-      before_action :authenticate_with_token!, only: %i[update]
+      before_action :authenticate_with_token!, only: %i[create update]
       before_action :admin, only: %i[create]
-      before_action :set_announcement, only: %i[update]
+      before_action :set_announcement, only: %i[show update]
 
       def show
         render json: serialize_announcement, status: :ok
@@ -13,9 +13,10 @@ module Api
 
       def create
         @announcement = Announcement.new(announcement_params)
-        @announcement.type = 'news'
+        @announcement.announcement_type = 'news'
+        @announcement.upload_image(params[:announcement][:image])
         @announcement.save!
-        render json: announcement_serializer, status: :created
+        render json: serialize_announcement, status: :created
       end
 
       def update

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -17,8 +17,8 @@ module Api
       def create
         @user = User.new(user_params)
         @user.role = Role.find_or_create_by!(name: 'user', description: 'usuario de la aplicacion')
-        token = JsonWebToken.encode(user_id: @user.id)
         @user.save!
+        token = JsonWebToken.encode(user_id: @user.id)
         UserWelcome.with(user: @user).send_user_welcome.deliver_later
         render json: { serialize_user: serialize_user, token: token }, status: :created
       end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #
@@ -30,7 +30,7 @@ class Announcement < ApplicationRecord
 
   validates :name, presence: true, length: { minimum: 2 }
   validates :content, presence: true, length: { minimum: 2 }
-  validates :type, presence: true, length: { minimum: 2 }
+  validates :announcement_type, presence: true, length: { minimum: 2 }
   validate :check_image_presence
 
   def check_image_presence

--- a/app/serializers/announcement_serializer.rb
+++ b/app/serializers/announcement_serializer.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #
@@ -25,7 +25,7 @@
 class AnnouncementSerializer
   include JSONAPI::Serializer
 
-  attributes :name, :content, :type
+  attributes :name, :content, :announcement_type
 
   belongs_to :category
 end

--- a/db/migrate/20220317161805_rename_type_to_announcement_type.rb
+++ b/db/migrate/20220317161805_rename_type_to_announcement_type.rb
@@ -1,0 +1,5 @@
+class RenameTypeToAnnouncementType < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :announcements, :type, :announcement_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_10_003916) do
+ActiveRecord::Schema.define(version: 2022_03_17_161805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2022_03_10_003916) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
     t.bigint "category_id", null: false
-    t.string "type", null: false
+    t.string "announcement_type", null: false
     t.index ["category_id"], name: "index_announcements_on_category_id"
     t.index ["discarded_at"], name: "index_announcements_on_discarded_at"
   end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #
@@ -26,7 +26,7 @@ FactoryBot.define do
   factory :announcement do
     name { Faker::TvShows::BreakingBad.character }
     content { Faker::Books::Lovecraft.sentence }
-    type { Faker::Lorem.word }
+    announcement_type { Faker::Lorem.word }
 
     trait :discarded do
       discarded_at { rand(1..1_000_000).days.ago }

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #
@@ -40,8 +40,8 @@ RSpec.describe Announcement, type: :model do
     it { is_expected.to validate_length_of(:name).is_at_least(2) }
     it { is_expected.to validate_presence_of(:content) }
     it { is_expected.to validate_length_of(:content).is_at_least(2) }
-    it { is_expected.to validate_presence_of(:type) }
-    it { is_expected.to validate_length_of(:type).is_at_least(2) }
+    it { is_expected.to validate_presence_of(:announcement_type) }
+    it { is_expected.to validate_length_of(:announcement_type).is_at_least(2) }
   end
 
   describe 'database' do
@@ -49,7 +49,12 @@ RSpec.describe Announcement, type: :model do
     it { is_expected.to have_db_column(:content).of_type(:text).with_options(null: false) }
     it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
-    it { is_expected.to have_db_column(:type).of_type(:string).with_options(null: false) }
+
+    it {
+      is_expected.to have_db_column(:announcement_type)
+        .of_type(:string).with_options(null: false)
+    }
+
     it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
   end


### PR DESCRIPTION
Se corrigen varios errores del controlador `announcements`.
- Renombrar la columna `type` para evitar conflictos al momento de generar pruebas de request.
- Actualizar el modelo,su correspondiente test, el factory y el serializer; acorde al nuevo nombre de la columna.
- Corregir errores de implementación del controlador.
- Actualizar las rutas al fix del [PR#59](https://github.com/alkemyTech/OT151-SERVER/pull/59/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5)
