### PR TITLE
feat/OT151-58: add slides doc

### DIFF
--- a/app/serializers/slides_serializer.rb
+++ b/app/serializers/slides_serializer.rb
@@ -6,6 +6,8 @@ class SlidesSerializer
   attribute :image do |object|
     return object.image_url if Rails.env.production?
 
-    ActiveStorage::Blob.service.path_for(object.image.key) if Rails.env.development?
+    if Rails.env.development? || Rails.env.test?
+      ActiveStorage::Blob.service.path_for(object.image.key)
+    end
   end
 end

--- a/spec/integration/api/v1/slides/index_spec.rb
+++ b/spec/integration/api/v1/slides/index_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+describe 'Slides API V1 Docs', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  let(:Authorization) { admin_header }
+
+  path '/api/v1/slides' do
+    get 'Fetch slides' do
+      tags :Slides
+      produces 'application/json'
+      security [JWT: {}]
+      parameter name: :Authorization, in: :header, type: :apiKey
+
+      response '200', 'Slides found' do
+        before { create_list(:slide, 5) }
+
+        schema type: :object, properties: {
+          slide: {
+            type: :object,
+            items: { '$ref' => '#/definitions/Slide' }
+          }
+        }
+        include_context 'with integration test'
+      end
+    end
+  end
+end

--- a/spec/support/shared_contexts/integration_test.rb
+++ b/spec/support/shared_contexts/integration_test.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 shared_context 'with integration test' do
   run_test!
   after do |example|
-    binding
     example.metadata[:response][:examples] =
       { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
   end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -33,6 +33,13 @@ RSpec.configure do |config|
         }
       ],
       definitions: {
+        Slide: {
+          type: 'object',
+          properties: {
+            id: { type: :integer, example: '1' },
+            order: { type: :integer, example: '1' },
+            image: { type: :string, example: '/img/file.jpg' }
+          },
         Announcement: {
           type: 'object',
           properties: {
@@ -49,14 +56,25 @@ RSpec.configure do |config|
             name: 'Authorization',
             in: :header,
             type: :apiKey
+<<<<<<< HEAD
           },
           properties: {
             token: { type: :string, example: "#{JsonWebToken.encode({ user_id: 0 })}" }
         }
+=======
+            },
+            properties: {
+              token: { type: :string, example: "#{JsonWebToken.encode({ user_id: 0 })}" }
+          }
+>>>>>>> 6d9567d (feat/OT151-58: add slides doc)
         }
       }
     }
   }
+<<<<<<< HEAD
+=======
+
+>>>>>>> 6d9567d (feat/OT151-58: add slides doc)
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
   # The swagger_docs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados
- **db/migrate/20220317161805_rename_type_to_announcement_type.rb**: Cambió consistente con el fix del [PR#61: feat/OT151: change column name of announcements table](https://github.com/alkemyTech/OT151-SERVER/pull/61/files#diff-e5adbce950e34c2d5a76f53e8c83bbe458e33dc4f1f0570336f5073de0cc2eb4) que corrige errores de implementación.

- **app/**
  + **serializers/slides_serializer.rb.rb**: Modificación para poder serializar la ruta de la imagen en entorno de pruebas.
  + **serializers/announcement_serializer.rb**: Cambió consistente con el fix del [PR#61: feat/OT151: change column name of announcements table](https://github.com/alkemyTech/OT151-SERVER/pull/61/files#diff-2742dbedae0bfc45f40cc5bc25294bf4f9436b1ead2b475b4db44600548911e5) que corrige errores de implementación.

- **spec/**
  + **factories/announcements.rb**: Cambió consistente con el fix del [PR#61: feat/OT151: change column name of announcements table](https://github.com/alkemyTech/OT151-SERVER/pull/61/files#diff-894afb5544f1fdd44868c86c82594c416ea94dfcbc6b3dc83f087b3c0c18a2bb) que corrige errores de implementación.
  + **models/announcement_spec.rb**: Cambió consistente con el fix del [PR#61: feat/OT151: change column name of announcements table](https://github.com/alkemyTech/OT151-SERVER/pull/61/files#diff-b5084e7fec520b2bc5ccd442a3fd17e1e0931854eb62d2039e49526176d1c3db) que corrige errores de implementación.
  + **requests/api/v1/users/auth_spec.rb**: Cambió consistente con el fix del [PR#59: FIxed some routes and spec tests of Users and Auth](https://github.com/alkemyTech/OT151-SERVER/pull/59/files#diff-1f9b65955b6c0e837dfa23094145bb76fe4399a8c1ec70699d1c2b16ee45b185) que corrige errores de implementación.
- **config/routes.rb**: Cambió consistente con el fix del [PR#59: FIxed some routes and spec tests of Users and Auth](https://github.com/alkemyTech/OT151-SERVER/pull/59/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5) que corrige errores de implementación.
- **spec/spec_helper.rb**: Incluye el módulo `RequestHelpers` para ser utilizado por todos los test.
- **.gitignore**: Agrega linea para ignorar archivos generados por la gema `rswag`
- **Gemfile**: Agrega las gemas para integrar _swagger_ y _rspec_
- **config/application.rb**: Configuración para para integrar _swagger_ y _rspec_

---
Nuevos archivos
- **config/initializers/**
  + **rswag-api.rb**: Configuración para integrar _swagger_ y _rspec_
  + **rswag-ui.rb**: Configuración para integrar _swagger_ y _rspec_
- **spec/**
  + **swagger_helper.rb**: Configuración para integrar _swagger_ y _rspec_
  + **integration/api/v1/slides/index_spec.rb**: Test para el documentar el endpoint `slides`.
  + **support/**
    - **shared_contexts/integration_test.rb**: Bloque de codigo reutilizado en `slides_spec.rb`.
    - **request_helpers.rb**: Agrega métodos utilizados por los tests.

---
### Comentario/s:
- Los test solo garantizan que se retorna el status correcto y datos coincidentes con el esquema definido. Para generar la documentación ejecutar los siguientes comandos:
```
bundle exec rspec spec/integration
RAILS_ENV=test bundle exec rake rswag:specs:swaggerize
rails server
```
