### PR TITLE
feat/OT151-60: test endpoint organizations

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -3,6 +3,9 @@
 module Api
   module V1
     class OrganizationsController < ApplicationController
+      before_action :authenticate_with_token!, only: %i[create]
+      before_action :admin, only: %i[create]
+
       # POST api/v1/organization/public
       def create
         @organization = Organization.create!(organization_params)

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #

--- a/app/serializers/announcement_serializer.rb
+++ b/app/serializers/announcement_serializer.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_08_160425) do
+ActiveRecord::Schema.define(version: 2022_03_17_161805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2022_03_08_160425) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
     t.bigint "category_id", null: false
-    t.string "type", null: false
+    t.string "announcement_type", null: false
     t.index ["category_id"], name: "index_announcements_on_category_id"
     t.index ["discarded_at"], name: "index_announcements_on_discarded_at"
   end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -4,14 +4,14 @@
 #
 # Table name: announcements
 #
-#  id           :bigint           not null, primary key
-#  content      :text             not null
-#  discarded_at :datetime
-#  name         :string           not null
-#  type         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category_id  :bigint           not null
+#  id                :bigint           not null, primary key
+#  announcement_type :string           not null
+#  content           :text             not null
+#  discarded_at      :datetime
+#  name              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  category_id       :bigint           not null
 #
 # Indexes
 #

--- a/spec/requests/api/v1/organizations/create_spec.rb
+++ b/spec/requests/api/v1/organizations/create_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Organizations', type: :request do
+  let(:header_for_admin) { admin_header }
+  let(:header_for_user) { auth_header(create(:user).id) }
+  let(:invalid_params) do
+    { organization: { email: '@email',
+                      name: 'nameveryloooooooooooooooooooooooooooooooooooong',
+                      welcome_text: ' ',
+                      address: 1,
+                      phone: '1234567890',
+                      about_us_text: '' } }
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters and admin user' do
+      before do
+        post '/api/v1/organization/public',
+             headers: header_for_admin,
+             params: { organization: attributes_for(:organization) },
+             as: :json
+      end
+
+      it 'creates a new Organization' do
+        expect do
+          post '/api/v1/organization/public',
+               headers: header_for_admin,
+               params: { organization: attributes_for(:organization) },
+               as: :json
+        end.to change(Organization, :count).by(1)
+      end
+
+      it 'returns http 201' do
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'with valid parameters and non-admin user' do
+      before do
+        post '/api/v1/organization/public',
+             headers: header_for_user,
+             params: { organization: attributes_for(:organization) },
+             as: :json
+      end
+
+      it 'returns http 403' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'with invalid parameters' do
+      before do
+        post '/api/v1/organization/public',
+             headers: header_for_admin,
+             params: invalid_params,
+             as: :json
+      end
+
+      it 'returns http 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@
 require 'simplecov'
 SimpleCov.start 'rails'
 
+require './spec/support/request_helpers'
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -48,4 +50,5 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.include RequestHelpers
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RequestHelpers
+  def body_json
+    JSON.parse(response.body)
+  end
+
+  def attributes_json
+    if body_json['serialize_user']
+      JSON.parse(body_json['serialize_user'])['data']['attributes']
+    else
+      body_json['data']['attributes']
+    end
+  end
+
+  def auth_header(user_id)
+    { 'Authorization' => "Bearer #{JsonWebToken.encode({ user_id: user_id })}" }
+  end
+
+  def admin_header
+    admin_id = create(:user, role_id: create(:role, name: 'admin').id).id
+    auth_header(admin_id)
+  end
+
+  def image_path
+    Rails.root.join('spec/factories_files/test.png')
+  end
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados
- **app/controllers/api/v1/organizations_controller.rb**: Se añade la autenticación y autorización del usuario para el método `index`.
- **spec/spec_helper.rb**: Incluye el módulo `RequestHelper` para ser utilizado por todos los test.

---
Nuevos archivos
- **spec/**
  + **requests/api/v1/organizations/create_spec.rb**: Test para el documentar el endpoint `organizations`.
  + **support/request_helper.rb**: Agrega métodos utilizados por los tests.

---
### Comentario/s:
- Se asume que el [ticket 60](https://alkemy-labs.atlassian.net/browse/OT151-60) ese refiere al enpoint correspondiente a `organizations`.
- El resto de los archivos modificados corresponden correcciones de otros tickets.