### PR TITLE
feat/OT151-52: add endpoint post announcement/:id/comments

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CommentsController < ApplicationController
+      before_action :authenticate_with_token!, only: %i[create]
+      before_action :find_announcement, only: %i[create]
+
+      def create
+        @comment = Comment.create!(comment_params)
+        render json: @comment.to_json, status: :created
+      end
+
+      private
+
+      def comment_params
+        params.require(:comment).permit(:body).merge(user_id: @current_user.id,
+                                                     announcement_id: @announcement.id)
+      end
+
+      def find_announcement
+        @announcement = Announcement.find(params[:announcement_id])
+      end
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: comments
+#
+#  id              :bigint           not null, primary key
+#  body            :text             not null
+#  discarded_at    :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  announcement_id :bigint           not null
+#  user_id         :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_announcement_id  (announcement_id)
+#  index_comments_on_discarded_at     (discarded_at)
+#  index_comments_on_user_id          (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (announcement_id => announcements.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Comment < ApplicationRecord
+  include Discard::Model
+
+  belongs_to :user
+  belongs_to :announcement
+  
+  validates :body, presence: true, length: { minimum: 2 }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
       post 'auth/login', to: 'auth#create'
       post 'auth/register', to: 'users#create'
       resources :announcements, only: %i[show update create]
+      resources :announcements, :shallow => true do 
+        resources :comments, only: :create
+      end
       resources :categories, only: %i[show create update destroy]
       resources :members, only: %i[index]
       resources :slides, only: %i[index]

--- a/db/migrate/20220318231848_create_comments.rb
+++ b/db/migrate/20220318231848_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :announcement, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220318233208_add_discarded_at_to_comments.rb
+++ b/db/migrate/20220318233208_add_discarded_at_to_comments.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :comments, :discarded_at, :datetime
+    add_index :comments, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_17_161805) do
+ActiveRecord::Schema.define(version: 2022_03_18_233208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,18 @@ ActiveRecord::Schema.define(version: 2022_03_17_161805) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
     t.index ["discarded_at"], name: "index_categories_on_discarded_at"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "announcement_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "discarded_at"
+    t.index ["announcement_id"], name: "index_comments_on_announcement_id"
+    t.index ["discarded_at"], name: "index_comments_on_discarded_at"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "members", force: :cascade do |t|
@@ -147,6 +159,8 @@ ActiveRecord::Schema.define(version: 2022_03_17_161805) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "announcements", "categories"
+  add_foreign_key "comments", "announcements"
+  add_foreign_key "comments", "users"
   add_foreign_key "slides", "organizations"
   add_foreign_key "users", "roles"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id              :bigint           not null, primary key
+#  body            :text             not null
+#  discarded_at    :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  announcement_id :bigint           not null
+#  user_id         :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_announcement_id  (announcement_id)
+#  index_comments_on_discarded_at     (discarded_at)
+#  index_comments_on_user_id          (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (announcement_id => announcements.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :comment do
+    body { Faker::FunnyName.two_word_name }
+    user
+    announcement
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -49,12 +49,7 @@ RSpec.describe Announcement, type: :model do
     it { is_expected.to have_db_column(:content).of_type(:text).with_options(null: false) }
     it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
-
-    it {
-      is_expected.to have_db_column(:announcement_type)
-        .of_type(:string).with_options(null: false)
-    }
-
+    it { is_expected.to have_db_column(:announcement_type).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: comments
+#
+#  id              :bigint           not null, primary key
+#  body            :text             not null
+#  discarded_at    :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  announcement_id :bigint           not null
+#  user_id         :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_announcement_id  (announcement_id)
+#  index_comments_on_discarded_at     (discarded_at)
+#  index_comments_on_user_id          (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (announcement_id => announcements.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  subject { build(:comment) }
+
+  describe 'factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:announcement) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_length_of(:body).is_at_least(2) }
+  end
+
+  describe 'database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:body).of_type(:text).with_options(null: false) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
+    it { is_expected.to have_db_index(:announcement_id) }
+    it { is_expected.to have_db_index(:discarded_at) }
+    it { is_expected.to have_db_index(:user_id) }
+  end
+end

--- a/spec/requests/api/v1/comments/create_spec.rb
+++ b/spec/requests/api/v1/comments/create_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Comments', type: :request do
+  let(:id) { create(:announcement).id }
+  let(:header_valid) { auth_header(create(:user).id) }
+  let(:header_invalid) { auth_header(-1) }
+  let(:invalid_params) do
+    { comment: { body: '@' } }
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters and authenticate' do
+      before do
+        post "/api/v1/announcements/#{id}/comments",
+             params: { comment: attributes_for(:comment) },
+             headers: header_valid,
+             as: :json
+      end
+
+      it 'creates a new Comment' do
+        expect do
+          post "/api/v1/announcements/#{id}/comments",
+               params: { comment: attributes_for(:comment) },
+               headers: header_valid,
+               as: :json
+        end.to change(Comment, :count).by(1)
+      end
+
+      it 'returns http 201' do
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'with valid parameters and non-authenticate' do
+      before do
+        post "/api/v1/announcements/#{id}/comments",
+             params: { comment: attributes_for(:comment) },
+             headers: header_invalid,
+             as: :json
+      end
+
+      it 'not creates a new Comment' do
+        expect do
+          post "/api/v1/announcements/#{id}/comments",
+               params: { comment: attributes_for(:comment) },
+               headers: header_invalid,
+               as: :json
+        end.to change(Comment, :count).by(0)
+      end
+
+      it 'returns http 401' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with invalid parameters' do
+      before do
+        post "/api/v1/announcements/#{id}/comments",
+             params: invalid_params,
+             headers: header_valid,
+             as: :json
+      end
+
+      it 'returns http 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Comments", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/api/v1/comments/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
### Resumen

---
Los archivos de la rama `main` modificados
- **app/** Modificaciones para resolver conflictos de la columna `type` reemplazada por `announcements_type`
  + **controllers/api/v1/announcements_controller.rb**
  + **models/announcement.rb**:
  + **serializers/announcement_serializer.rb**:
- **config/routes.rb**: Se añade la ruta al endpoint `comments`
- **spec/spec_helper.rb**: Incluye el módulo `RequestHelper` para ser utilizado por todos los test.
- **spec/** Modificaciones para resolver conflictos de la columna `type` reemplazada por `announcements_type`
  + **factories/announcements.rb**:
  + **models/announcement_spec.rb**:

---
Nuevos archivos
- **app/** 
  + **controllers/api/v1/comments_controller.rb**: Implementa la acción `create`
  + **app/models/comment.rb**
- **db/migrate/**
  + **20220318231848_create_comments.rb**
  + **20220318233208_add_discarded_at_to_comments.rb**
- **spec/**
  + **factories/comments.rb**
  + **models/comment_spec.rb**
  + **requests/api/v1/comments_spec.rb**
  + **support/request_helpers.rb**: Agrega métodos utilizados por los tests.

---
### Comentario/s:
- Se asume que el ticket refiere a `post` como la tabla `announcements`.
- Se decide no agregar la linea `has_many :comments` en _/app/models/announcement.rb_ hasta que se realice el merge entre las versiones que modificaron el campo `type` por `announcements_type`.
- Para una futura versión, se podria implementar una relación polimorfica para que un una instancia de `comment` pueda pertenecer a una de `announcement` o a otra de `comment`.

