### PR TITLE
fix/OT151: auth controller - post create and get show

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -11,13 +11,14 @@ module Api
       def create
         raise AuthenticationError unless auth_user
 
-        render json: serialize_user, status: :created
+        @options = { meta: { jwt: JsonWebToken.encode(user_id: @user.id) } }
+        render json: serialize_user(@user, @options), status: :created
       end
 
       # GET api/v1/auth/me
       def show
         if @current_user
-          render json: serialize_user, status: :ok
+          render json: serialize_user(@current_user), status: :ok
         else
           render json: { ok: false }
         end
@@ -37,8 +38,8 @@ module Api
         @user = User.find_by!(email: params.require(:email))
       end
 
-      def serialize_user
-        UserSerializer.new(@user).serializable_hash.to_json
+      def serialize_user(*args)
+        UserSerializer.new(*args).serializable_hash.to_json
       end
     end
   end


### PR DESCRIPTION
la acción `create` retorna el siguiente formato:
```sh
{
    "data": {
        "id": "2",
        "type": "user",
        "attributes": {
            "email": "comun@email.com",
            "first_name": "comun",
            "last_name": "MacGyver",
            "role_id": 2
        }
    },
    "meta": {
        "jwt": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJleHAiOjE2NDc3ODIzODJ9.E2XQoYQCbawG8xfawImNMx3LYYagHFSMVTziqu6TVFA"
    }
}
```
Se elije la estrategia de serializar el token a diferencia de la acción `create` del controlador de usuario
```ruby
# app/controllers/api/v1/users_controller.rb
      # POST /api/v1/auth/register
      def create
        @user = User.new(user_params)
        # [...]
        render json: { serialize_user: serialize_user, token: token }, status: :created
      end

```

```sh
{
    "serialize_user": "{\"data\":{\"id\":\"3\",\"type\":\"user\",\"attributes\":{\"email\":\"comun@email.org\",\"first_name\":\"first_name\",\"last_name\":\"last_name\",\"role_id\":2}}}",
    "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjpudWxsLCJleHAiOjE2NDc3ODMxMjZ9.vZ2DFzJF8rCmk_H1Mlofqc4CrCIT1JJeZTCYB3fgfw0"
}
```

> Nota: El controlador de usuario tiene un error por lo que genera tokens sin el valor de `id`

```sh
JsonWebToken.decode("eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjpudWxsLCJleHAiOjE2NDc3ODMxMjZ9.vZ2DFzJF8rCmk_H1Mlofqc4CrCIT1JJeZTCYB3fgfw0")

=> {"user_id"=>nil, "exp"=>1647783126}
```