### PR TITLE
feat/OT151-57: add testimonials docs

### DIFF
--- a/spec/integration/api/v1/testimonials/create_spec.rb
+++ b/spec/integration/api/v1/testimonials/create_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'Testimonial API V1 Docs', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  let(:Authorization) { admin_header }
+
+  path '/api/v1/testimonials' do
+    post 'Create a testimonial' do
+      tags :Testimonial
+      consumes 'application/json'
+      security [JWT: {}]
+      parameter name: :Authorization, in: :header, type: :apiKey
+      parameter name: :params, in: :body, schema: {
+        type: :object,
+        properties: {
+          testimonial: {
+            type: :object,
+            properties: { name: { type: :string }, content: { type: :string } },
+            required: %w[name content]
+          }
+        },
+        required: ['testimonial']
+      }
+      produces 'application/json'
+
+      response '201', 'Testimonial created' do
+        let(:params) do
+          { testimonial: {
+            name: Faker::TvShows::BreakingBad.character,
+            content: Faker::Books::Lovecraft.sentence
+          } }
+        end
+        include_context 'with integration test'
+      end
+
+      response '422', 'Testimonial creation failed for parameter missing' do
+        let(:params) { { name: '', content: '' } }
+        include_context 'with integration test'
+      end
+    end
+  end
+end

--- a/spec/integration/api/v1/testimonials/index_spec.rb
+++ b/spec/integration/api/v1/testimonials/index_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+describe 'Testimonial API V1 Docs', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  path '/api/v1/testimonials' do
+    get 'Fetch testimonials' do
+      tags :Testimonial
+      produces 'application/json'
+      response '200', 'Testimonial found' do
+        before { create_list(:testimonial, 10) }
+
+        schema type: :object, properties: {
+          Testimonial: {
+            type: :object,
+            items: { '$ref' => '#/definitions/Testimonial' }
+          }
+        }
+        include_context 'with integration test'
+      end
+    end
+  end
+  
+  path "/api/v1/testimonials?page={page}" do
+    get 'Fetch testimonials' do
+      tags :Testimonial
+      produces 'application/json'
+      response '200', 'Testimonial found' do
+        before { create_list(:testimonial, 33) }
+
+        parameter name: :page, in: :path, type: :string
+        schema type: :object, properties: {
+          Testimonial: {
+            type: :object,
+            items: { '$ref' => '#/definitions/Testimonial' }
+          }
+        }
+        let(:page) { 4 }
+        include_context 'with integration test'
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -50,13 +50,24 @@ RSpec.configure do |config|
             category_id: { type: :integer, example: '1' }
           }
         },
+        Testimonial: {
+          type: 'object',
+          properties: {
+            id: { type: :integer, example: '1' },
+            name: { type: :string, example: 'name' },
+            description: { type: :string, example: 'description' },
+            announcement_type: { type: :string, example: 'announcement_type' },
+            category_id: { type: :integer, example: '1' }
+          }
+        },
         Member: {
           type: 'object',
           properties: {
             id: { type: :integer, example: '100' },
             name: { type: :string, example: 'test' },
             description: { type: :string, example: 'test' },
-            image: { type: :string, example: '/img/file.jpg' }
+            image: { type: :string, example: '/img/file.jpg' },
+            content: { type: :string, example: 'description' }
           }
         },
         securityDefinitions: {
@@ -67,7 +78,7 @@ RSpec.configure do |config|
             type: :apiKey
           },
           properties: {
-            token: { type: :string, example: "#{JsonWebToken.encode({ user_id: 0 })}" }
+            token: { type: :string, example: JsonWebToken.encode({ user_id: 0 }).to_s }
           }
         }
       }


### PR DESCRIPTION
# Instrucciones
> Actualización 23-03-22
> **Este PR NO DEBE SER MERGEADO**
---
Para la configuración dada, basado en la recomendación oficial de la gema [rswag](https://github.com/rswag/rswag#getting-started), se debe ejecutar los siguientes comandos, para garantizar que se genere la documentación correcta.
```
bundle exec rspec spec/integration/
bundle exec rake rswag:specs:swaggerize
RAILS_ENV=test rails s
```
Ingresar a http://localhost:3000/api-docs/index.html