### PR TITLE
Fixed factory for announcements

### DIFF
--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -38,12 +38,11 @@ FactoryBot.define do
       discarded_at { rand(1..1_000_000).days.ago }
     end
 
-    trait :with_image do
-      after :create do |announcement|
-        file_path = Rails.root.join('spec/factories_files/test.png'), 'image/png'
-        file = fixture_file_upload(file_path, 'image/png')
-        announcement.image.attach(file)
-      end
+    after(:build) do |announcement|
+      announcement.image.attach(
+        io: File.open(Rails.root.join('spec/factories_files/test.png')),
+        filename: 'test.png', content_type: 'image/jpeg'
+      )
     end
   end
 end


### PR DESCRIPTION
Arreglé el image attachment de announcements en la factory bot.

Simplemente cambia el with_image trait (que no se debería usar para parámetros obligatorios) con un callback after(:build).